### PR TITLE
Scroll to index new version for the scheduler binding issue

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  scroll_to_index: ^2.1.1
+  scroll_to_index: ^3.0.1
   rect_getter: ^1.1.0
   flutter_web_plugins:
     sdk: flutter


### PR DESCRIPTION
After the new flutter update, this warning keeps popping out
/opt/homebrew/Caskroom/flutter/3.0.2/flutter/.pub-cache/hosted/pub.dartlang.org/scroll_to_index-2.1.1/lib/scroll_to_index.dart:358:57: Warning: Operand of null-aware operation '!' has type 'SchedulerBinding' which excludes null.
- 'SchedulerBinding' is from 'package:flutter/src/scheduler/binding.dart' ('/opt/homebrew/Caskroom/flutter/3.0.2/flutter/packages/flutter/lib/src/scheduler/binding.dart').
package:flutter/…/scheduler/binding.dart:1
  Future _waitForWidgetStateBuild() => SchedulerBinding.instance!.endOfFrame;

the solution is to upgrade the scroll to index to latest version.