### PR TITLE
fix call animateAndScrollTo method twice

### DIFF
--- a/lib/vertical_scrollable_tabview.dart
+++ b/lib/vertical_scrollable_tabview.dart
@@ -89,8 +89,8 @@ class _VerticalScrollableTabViewState extends State<VerticalScrollableTabView>
       // will call two times, because 底層呼叫 2 次 notifyListeners()
       // https://stackoverflow.com/questions/60252355/tabcontroller-listener-called-multiple-times-how-does-indexischanging-work
       if (VerticalScrollableTabBarStatus.isOnTap) {
-        animateAndScrollTo(VerticalScrollableTabBarStatus.isOnTapIndex);
         VerticalScrollableTabBarStatus.isOnTap = false;
+        animateAndScrollTo(VerticalScrollableTabBarStatus.isOnTapIndex);
       }
     });
     scrollController = AutoScrollController();


### PR DESCRIPTION
When tap tabbar item, then it calls animateAndScrollTo method twice.

Your comment at tabController.addListener, "will call two times, because 底層呼叫 2 次 notifyListeners()", is actually  not a real problem.
The problem is that when tap the tabbar item, before VerticalScrollableTabBarStatus.isOnTop mutex being false, animateAndScrollTo method calls twice. Because in the animatedAndScrollTo method, it calls scrollTo method once again before VerticalScrollableTabBarStatus.isOnTap mutex being false.

By setting isOnTap mutex to false firstly, it can be prevented.