### PR TITLE
fix: tab controller double dispose

### DIFF
--- a/lib/vertical_scrollable_tabview.dart
+++ b/lib/vertical_scrollable_tabview.dart
@@ -154,18 +154,14 @@ class _VerticalScrollableTabViewState extends State<VerticalScrollableTabView>
 
   @override
   void initState() {
-    widget._tabController.addListener(() {
-      if (VerticalScrollableTabBarStatus.isOnTap) {
-        VerticalScrollableTabBarStatus.isOnTap = false;
-        animateAndScrollTo(VerticalScrollableTabBarStatus.isOnTapIndex);
-      }
-    });
+    widget._tabController.addListener(_handleTabControllerTick);
     super.initState();
   }
 
   @override
   void dispose() {
-    widget._tabController.dispose();
+    widget._tabController.removeListener(_handleTabControllerTick);
+    // We don't own the _tabController, so it's not disposed here.
     super.dispose();
   }
 
@@ -301,5 +297,12 @@ class _VerticalScrollableTabViewState extends State<VerticalScrollableTabView>
       items.add(index);
     });
     return items;
+  }
+
+  void _handleTabControllerTick() {
+    if (VerticalScrollableTabBarStatus.isOnTap) {
+      VerticalScrollableTabBarStatus.isOnTap = false;
+      animateAndScrollTo(VerticalScrollableTabBarStatus.isOnTapIndex);
+    }
   }
 }


### PR DESCRIPTION
Currently the view is disposing provided `TabController` even though it's not owning it, which leads (even in examples) to double `dispose` call error. This resolves it by passing the dispose call responsibility to the user, but removing custom listener added on initialization. 